### PR TITLE
[Feature]: Added Mvec::operator/= overload with scalars.

### DIFF
--- a/data/Mvec.hpp
+++ b/data/Mvec.hpp
@@ -312,9 +312,17 @@ namespace project_namespace{
         friend Mvec<U> operator/(const S &value, const Mvec<U> &mv);
 
         /// \brief Overload the inverse with operator =, corresponds to this /= mv
-        /// \param mv - Mvec to be inversed to this object
+        /// \param mv - Mvec to be inverted to this object
         /// \return this /= mv
         Mvec& operator/=(const Mvec& mv);
+
+
+        /// \brief Overload the inverse with operator =, corresponds to this /= value
+        /// \param value - scalar to divide the object
+        /// \return this /= value
+        template<typename S>
+        Mvec& operator/=(const S &value);
+
 
         /// \brief the reverse of a multivector, i.e. if mv = a1^a2^...^an, then reverse(mv) = an^...^a2^a1
         /// \param mv - a multivector
@@ -1279,6 +1287,12 @@ project_singular_metric_comment_end
         return *this;
     }
 
+    template<typename T>
+    template<typename S>
+    Mvec<T> &Mvec<T>::operator/=(const S &value) {
+        *this = *this / value;
+        return *this;
+    }
 
     template<typename T>
     Mvec<T> operator~(const Mvec<T> &mv){


### PR DESCRIPTION
## Why

* `Mvec<T>::operator/=(Mvec const & mv)` is called when normalising multivectors in utility functions `extractTangentVector` and `extractDualCircle` in `plugin/c3gaTools.cpp`, as a result of `Mvec<T>::operator/=(S value)` not being defined (although `Mvec<T>::operator/(S value)` is.

## What

* Added overloaded `operator/=` for `Mvec<T>` with scalar types.

## How to test

1) Compile `garamon_generator` and generate the c3ga library.
2) Attempt to divide a `Mvec` by a scalar.
3) See that the scalar division is called. 
