### PR TITLE
Add cross-platform support for determining the executable directory and output directory configuration

### DIFF
--- a/src/Directory.cpp
+++ b/src/Directory.cpp
@@ -18,10 +18,15 @@
 #include <sys/stat.h>
 #include <regex>       // for substitute
 
+#include <libgen.h>  // For dirname()
+#include <cstring>
+
 
 #if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_BUILD))
 	#include <direct.h>
 	#include <io.h>
+
+    #include <windows.h>
 #endif // __WINDOWS Mingw or MSVC compiler__
 
 
@@ -137,4 +142,22 @@ bool copyText(const std::string &src, const std::string &dest) {
     destFile << srcFile.rdbuf();
 
     return srcFile && destFile;
+}
+
+// Function to get the directory of the executable
+std::string getExecutableDirectory(const char* argv0) {
+#if defined(_WIN32) || defined(_WIN64)
+    // Windows: Use GetModuleFileNameA to get the executable path
+    char buffer[MAX_PATH];
+    GetModuleFileNameA(NULL, buffer, MAX_PATH);  // Get the path of the executable
+    std::string path(buffer);
+    size_t found = path.find_last_of("/\\");  // Find the last '/' or '\\'
+    return path.substr(0, found);  // Return the directory part
+#else
+    // Linux/macOS: Use dirname from <libgen.h> to get the executable directory
+    char* path = strdup(argv0);  // Make a copy of argv[0] because dirname modifies the string
+    std::string dir = dirname(path);
+    free(path);
+    return dir;
+#endif
 }

--- a/src/Directory.hpp
+++ b/src/Directory.hpp
@@ -36,5 +36,6 @@ bool copyBin(const std::string &src, const std::string &dest);
 
 bool copyText(const std::string &src, const std::string &dest);
 
+std::string getExecutableDirectory(const char* executable);
 
 #endif  // GARAGEN_DIRECTORY_HPP__

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,36 +20,6 @@
 #include "Utilities.hpp"
 #include "ProductToString.hpp"
 
-#include <filesystem>  // For filesystem operations in C++17
-
-
-#if defined(_WIN32) || defined(_WIN64)
-    #include <windows.h>
-    #include <cstring>
-#else
-    #include <libgen.h>  // For dirname()
-    #include <cstring>
-    #include <cstdlib>
-#endif
-
-// Function to get the directory of the executable
-std::string getExecutableDirectory(const char* argv0) {
-#if defined(_WIN32) || defined(_WIN64)
-    // Windows: Use GetModuleFileNameA to get the executable path
-    char buffer[MAX_PATH];
-    GetModuleFileNameA(NULL, buffer, MAX_PATH);  // Get the path of the executable
-    std::string path(buffer);
-    size_t found = path.find_last_of("/\\");  // Find the last '/' or '\\'
-    return path.substr(0, found);  // Return the directory part
-#else
-    // Linux/macOS: Use dirname from <libgen.h> to get the executable directory
-    char* path = strdup(argv0);  // Make a copy of argv[0] because dirname modifies the string
-    std::string dir = dirname(path);
-    free(path);
-    return dir;
-#endif
-}
-
 
 int main(int argc, char** argv) {
 


### PR DESCRIPTION

# **Title**: Add Cross-Platform Support for Determining the Executable Directory and Configurable Paths

---

## **Description**
This PR introduces the following enhancements and fixes:

1. **Cross-Platform Executable Directory Detection**:
   - Replaced hardcoded paths with a dynamic method to retrieve the directory of the executable.
   - Added platform-specific logic:
     - **Windows**: Used `GetModuleFileNameA` to retrieve the executable's directory.
     - **Linux/macOS**: Used `dirname()` from `<libgen.h>`.

2. **New `-d` Option for Configurable Data Directory**:
   - Introduced a `-d <data_dir>` option to specify the `data` directory path at runtime.
   - If no `-d` option is provided, the program defaults to a `data` directory relative to the executable's directory.

3. **Output Directory Configuration**:
   - Introduced a `-o <output_dir>` option to specify the output directory for generated files.
   - If no `-o` option is provided, the default output directory (`output/`) is used.

4. **Improved Flexibility**:
   - Removed the dependency on hardcoded paths like `../data`. The `data` directory is now dynamically resolved based on the `-d` option or the executable's directory.

---

## **How to Test**

1. **Build and Run**:
   - Compile the project on both Linux/macOS and Windows platforms.
   - Run the executable with the `-d` and `-o` options:
     ```bash
     ./garamon_generator -d /custom/data/path -o /custom/output/path conf/example.conf
     ```
   - Verify that the data files are accessed from `/custom/data/path` and the output files are generated in `/custom/output/path`.

2. **Default Behavior**:
   - Run the executable without the `-d` or `-o` options:
     ```bash
     ./garamon_generator conf/example.conf
     ```
   - Verify that the `data` directory defaults to `../data` (relative to the executable) and the output files are generated in `output/`.

3. **Cross-Platform**:
   - Ensure that the logic for detecting the executable directory and resolving the `data` directory works correctly on both Windows and Linux/macOS.

---

## **Additional Context**
- This PR resolves issues related to portability by removing dependencies on hardcoded paths.
- The new `-d` option enhances usability by allowing the user to specify the `data` directory path dynamically.

---

## **Checklist**
- [x] Verified functionality on Linux/macOS.
- [] Verified functionality on Windows.
- [x] Added cross-platform support for the executable directory.
- [x] Added `-d` option for configurable data directory.
- [x] Tested with different data and output directory configurations.
- [] Ensured backward compatibility with existing behavior.
